### PR TITLE
Nix Integration

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,133 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1752687322,
+        "narHash": "sha256-RKwfXA4OZROjBTQAl9WOZQFm7L8Bo93FQwSJpAiSRvo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6e987485eb2c77e5dcc5af4e3c70843711ef9251",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pyproject-build-systems": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "pyproject-nix": [
+          "pyproject-nix"
+        ],
+        "uv2nix": [
+          "uv2nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1752574539,
+        "narHash": "sha256-Dl/TGWnrsmmyFVApbpoVosAwOjocJRP2VAoOVbYK+KA=",
+        "owner": "pyproject-nix",
+        "repo": "build-system-pkgs",
+        "rev": "dfa1792728c7a3c34e22491e9fa272ed24e53012",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "build-system-pkgs",
+        "type": "github"
+      }
+    },
+    "pyproject-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1752762157,
+        "narHash": "sha256-xF39K+Sd5+Sv2YqarHEwFpzCC3sKz83M7/tCg99/8Uk=",
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "rev": "fa35449a527d07cf3c7856687d18a999dd0dd241",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "pyproject-build-systems": "pyproject-build-systems",
+        "pyproject-nix": "pyproject-nix",
+        "uv2nix": "uv2nix"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "uv2nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "pyproject-nix": [
+          "pyproject-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1752805696,
+        "narHash": "sha256-GpqeCI2n6sSdIEY/vG9qbQOoN+4/ZcSEhnFeLXG/hxs=",
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
+        "rev": "8c77cd2cb5a9693e26fb8579f6a25565d99e400d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,7 @@
     flake-utils,
     ...
   } @ inputs: let
-    projectName = "flake_template";
+    projectName = "quaestor";
   in
     (flake-utils.lib.eachDefaultSystem (system: let
       uvBoilerplate = import nix/uv.nix {inherit inputs system projectName;};

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,62 @@
+{
+  description = "Flake Template: Template for working with uv2nix";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+
+    pyproject-nix = {
+      url = "github:pyproject-nix/pyproject.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    uv2nix = {
+      url = "github:pyproject-nix/uv2nix";
+      inputs.pyproject-nix.follows = "pyproject-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    pyproject-build-systems = {
+      url = "github:pyproject-nix/build-system-pkgs";
+      inputs.pyproject-nix.follows = "pyproject-nix";
+      inputs.uv2nix.follows = "uv2nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = {
+    self,
+    flake-utils,
+    ...
+  } @ inputs: let
+    projectName = "flake_template";
+  in
+    (flake-utils.lib.eachDefaultSystem (system: let
+      uvBoilerplate = import nix/uv.nix {inherit inputs system projectName;};
+      inherit
+        (uvBoilerplate)
+        pythonSet
+        workspace
+        ;
+    in
+      with uvBoilerplate; {
+        # Provide the package
+        # No opt dependencies for production
+        packages.default = pythonSet.mkVirtualEnv "${projectName}-env" workspace.deps.default;
+
+        # Make the project runnable with `nix run`
+        apps.default = {
+          type = "app";
+          program = "${self.packages.${system}.default}/bin/${projectName}";
+        };
+
+        # Make pytest available through nix flake check
+        checks = {inherit (pythonSet.${projectName}.passthru.tests) pytest;};
+
+        devShells = import nix/shell.nix {inherit inputs uvBoilerplate projectName;};
+      }))
+    // {
+      # overlays.default = import nix/overlay.nix;
+      # homeManagerModules.default = import nix/hm.nix;
+    };
+}

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,0 +1,2 @@
+# Package overlay to add flowgenius to scope
+{}

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,0 +1,113 @@
+# Dev Shells
+{
+  inputs,
+  uvBoilerplate,
+  projectName,
+  ...
+}: let
+  # From the boilerplate, pull in what we need
+  inherit
+    (uvBoilerplate)
+    lib
+    pkgs
+    workspace
+    pythonSet
+    python
+    ;
+
+  standartPackages = with uvBoilerplate.pkgs; [
+    # Unix utilities
+    coreutils # Basic file, shell and text manipulation utilities
+    findutils # Find, locate, and xargs commands
+    gnugrep # GNU grep, egrep and fgrep
+    gnused # GNU stream editor
+    ripgrep # Fast line-oriented search tool
+    fd # Simple, fast and user-friendly alternative to find
+    bat # Cat clone with syntax highlighting
+    eza # Modern replacement for ls
+    htop # Interactive process viewer
+    jq # Lightweight JSON processor
+    watch # Execute a program periodically
+    curl # Command line tool for transferring data
+    wget # Internet file retriever
+    tree # Display directories as trees
+    unzip # Unzip utility
+    zip # Zip utility
+  ];
+in {
+  # The default shell, where nix manages the venv and dependencies
+  # The venv is editable for the local projects
+  default = let
+    # This overlay enables editable mode for all local dependencies
+    editableOverlay = workspace.mkEditablePyprojectOverlay {
+      # Pull in the environment var
+      root = "$REPO_ROOT";
+      # Optional; only enable editable for certain packages
+      # members = [ projectName ];
+    };
+
+    # Override previous python set with the overrideable overlay
+    editablePythonSet = pythonSet.overrideScope (
+      lib.composeManyExtensions [
+        editableOverlay
+
+        # Apply fixups for building an editable package of your workspace packages
+        (final: prev: {
+          ${projectName} = prev.${projectName}.overrideAttrs (old: {
+            # It's a good idea to filter the sources going into an editable build
+            # so the editable package doesn't have to be rebuilt on every stage
+            src = lib.fileset.toSource {
+              root = old.src;
+              fileset = lib.fileset.unions [
+                (old.src + "/pyproject.toml")
+                (old.src + "/README.md")
+                (old.src + "/src/${projectName}/__init__.py")
+              ];
+            };
+
+            # Hatchling (build system) has a dependency on the editables package when building editables
+            # In normal python flows this dependency is dynamically handled, in PEP660
+            # With Nix, the dependency needs to be explicitly declared
+            nativeBuildInputs =
+              old.nativeBuildInputs
+              ++ final.resolveBuildSystem {
+                editables = [];
+              };
+          });
+        })
+      ]
+    );
+
+    # Build our editable python to a virtual environment
+    # All optional dependencies are asked for in development
+    virtualenv = editablePythonSet.mkVirtualEnv "${projectName}-dev-env" workspace.deps.all;
+  in (
+    pkgs.mkShell {
+      packages =
+        standartPackages
+        ++ [virtualenv pkgs.uv]
+        ++ [
+          # Add additional shell projects here
+        ];
+
+      env = {
+        # Don't create venv using uv
+        UV_NO_SYNC = "1";
+
+        # Force uv to use Python interpreter from venv
+        UV_PYTHON = python.interpreter;
+
+        # Prevent uv from downloading managed Python's
+        UV_PYTHON_DOWNLOADS = "never";
+      };
+
+      shellHook = ''
+        # Undo dependency propagation by nixpkgs.
+        unset PYTHONPATH
+
+        # Get repository root using git. This is expanded at runtime by the editable `.pth` machinery.
+        export REPO_ROOT=$(git rev-parse --show-toplevel)
+      '';
+    }
+  );
+}

--- a/nix/uv.nix
+++ b/nix/uv.nix
@@ -1,0 +1,101 @@
+# UV boilerplate abstraction
+# We want to take flake inputs, nd the current system
+{
+  inputs,
+  system,
+  projectName,
+  ...
+}: rec {
+  # Explicitly name our inputs that we'll use
+  inherit (inputs) nixpkgs uv2nix pyproject-nix pyproject-build-systems;
+
+  # Pull lib into scope
+  inherit (nixpkgs) lib;
+
+  # Create pkgs set from our current system
+  pkgs = nixpkgs.legacyPackages.${system};
+  inherit (pkgs) stdenv;
+
+  # We use python 3.13
+  python = pkgs.python313;
+  baseSet = pkgs.callPackage pyproject-nix.build.packages {inherit python;};
+
+  # We load a uv workspace from a workspace root
+  workspace = uv2nix.lib.workspace.loadWorkspace {workspaceRoot = ../.;};
+
+  # Create package overlay from workspace
+  overlay = workspace.mkPyprojectOverlay {
+    # Prefer prebuilt binary wheels as a package source
+    sourcePreference = "wheel";
+  };
+
+  # Extend generated overlay with build fixups
+  #
+  # Uv2nix can only work with what it has, and uv.lock is missing essential metadata to perform some builds.
+  # This is an additional overlay implementing build fixups.
+  # See:
+  # - https://pyproject-nix.github.io/uv2nix/FAQ.html
+  pyprojectOverrides = final: prev: {
+    # Implement build fixups here.
+    # Note that uv2nix is _not_ using Nixpkgs buildPythonPackage.
+    # It's using https://pyproject-nix.github.io/pyproject.nix/build.html
+    ${projectName} = prev.${projectName}.overrideAttrs (old: {
+      passthru =
+        old.passthru
+        // {
+          # Put all tests in the passthru.tests attribute set.
+          # Nixpkgs also uses the passthru.tests mechanism for ofborg test discovery.
+          #
+          # For usage with Flakes we will refer to the passthru.tests attributes
+          # to construct the flake checks attribute set.
+          tests = let
+            virtualenv = final.mkVirtualEnv "${projectName}-pytest-env" {
+              ${projectName} = ["test"];
+            };
+          in
+            (old.tests or {})
+            // {
+              pytest = stdenv.mkDerivation {
+                name = "${final.${projectName}.name}-pytest";
+                inherit (final.${projectName}) src;
+                nativeBuildInputs = [
+                  virtualenv
+                ];
+                dontConfigure = true;
+
+                # Because this package is running tests, and not actually building the main package
+                # the build phase is running the tests.
+                #
+                # In this particular example we also output a HTML coverage report, which is used as the build output.
+                buildPhase = ''
+                  runHook preBuild
+                  pytest --cov tests --cov-report html
+                  runHook postBuild
+                '';
+
+                # Install the HTML coverage report into the build output.
+                #
+                # If you wanted to install multiple test output formats such as TAP outputs
+                # you could make this derivation a multiple-output derivation.
+                #
+                # See https://nixos.org/manual/nixpkgs/stable/#chap-multiple-output for more information on multiple outputs.
+                installPhase = ''
+                  runHook preInstall
+                  mv htmlcov $out
+                  runHook postInstall
+                '';
+              };
+            };
+        };
+    });
+  };
+
+  # Construct package set
+  pythonSet = baseSet.overrideScope (
+    lib.composeManyExtensions [
+      pyproject-build-systems.overlays.default
+      overlay
+      pyprojectOverrides
+    ]
+  );
+}


### PR DESCRIPTION
This pull request packages quaestor for nix, allowing the repo to be referred to as a flake.

Quaestor should be available , so it's pretty helpful for people using nix based dev environments. In nix enabled environments, quaestor can be run with the following command without installing;

```
nix run githubh;jeanluciano/quaestor -- <args>
```

And quaestor can be included easily in a dev shell, by adding it to flake inputs and referring to the default package.

```flake.nix
{
  inputs = {
    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
    flake-utils.url = "github:numtide/flake-utils";
    ...
    quaestor = {
      url = "github:jeanluciano/quaestor";
      inputs.nixpkgs.follows = "nixpkgs";
    };
    ...
  };
  outputs = {
    ...,
  } @ inputs: inputs.flake-utils.lib.eachDefaultSystem (system: let
    pkgs = import nixpkgs {inherit system;};
    quaestor = inputs.quaestor.packages.${system}.default;
    ...
  in {
    ...
    devShell = pkgs.mkShell {
      ...
      packages = [
        ...
        quaestor
      ];
    };
    ...
  };
}
```