### PR TITLE
Add "Run in Smithery" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Quaestor
 
+[![Run in Smithery](https://smithery.ai/badge/skills/jeanluciano)](https://smithery.ai/skills?ns=jeanluciano&utm_source=github&utm_medium=badge)
+
+
 > A minimal Claude Code plugin for specification-driven development
 
 [![PyPI Version](https://img.shields.io/pypi/v/quaestor.svg)](https://pypi.org/project/quaestor/)


### PR DESCRIPTION
## Add skill discoverability badge

Your 7 Claude skills are already indexed on [Smithery](https://smithery.ai), a directory of Agent Skills and MCP servers. This badge links users directly to your skills.

### Badge Preview
[![Run in Smithery](https://smithery.ai/badge/skills/jeanluciano)](https://smithery.ai/skills?ns=jeanluciano&utm_source=github&utm_medium=badge)

### Why add this?
- Users browsing your repo can discover and install your skills with one click
- No additional setup required - your skills are already listed

---

This is optional. Feel free to close if you prefer not to add external badges.